### PR TITLE
Fix socket.gethostbyname() exception on OSX by replacing with 127.0.0.1

### DIFF
--- a/eslogging/handlers.py
+++ b/eslogging/handlers.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import platform
 import re
 import socket
 import sys
@@ -218,8 +219,21 @@ class ESHandler(logging.Handler):
             self.es_additional_fields = {}
         else:
             self.es_additional_fields = es_additional_fields.copy()
-        self.es_additional_fields.update({'host': socket.gethostname(),
-                                          'host_ip': socket.gethostbyname(socket.gethostname())})
+
+        host = socket.gethostname()
+        if platform.system() != 'Darwin':
+            try:
+                host_ip = socket.gethostbyname(host)
+            except Exception as err:
+                if err.errno == 8:
+                    host_ip = '127.0.0.1'
+                else:
+                    raise err
+        else:
+            host_ip = '127.0.0.1'
+        self.es_additional_fields.update({'host': host,
+                                          'host_ip': host_ip})
+
         self.raise_on_indexing_exceptions = raise_on_indexing_exceptions
         self.default_timestamp_field_name = default_timestamp_field_name
         self._timed_flush = timed_flush


### PR DESCRIPTION
On OSX (Mojave but also any newer ones) hostname is on the .local domain and it will not be resolved via dns.